### PR TITLE
Adds server route to relay Instagram API calls.

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,8 @@
   },
   "homepage": "https://github.com/ohjonah/selfie-spots#readme",
   "dependencies": {
-    "express": "^4.15.3"
+    "dotenv": "^4.0.0",
+    "express": "^4.15.3",
+    "express-request-proxy": "^2.0.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -17,5 +17,8 @@
   "bugs": {
     "url": "https://github.com/ohjonah/selfie-spots/issues"
   },
-  "homepage": "https://github.com/ohjonah/selfie-spots#readme"
+  "homepage": "https://github.com/ohjonah/selfie-spots#readme",
+  "dependencies": {
+    "express": "^4.15.3"
+  }
 }

--- a/public/index.html
+++ b/public/index.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Selfie Spots</title>
+
+    <link rel="stylesheet" href="styles/modules.css">
+  </head>
+  <body>
+    <main>
+      <section id="main">
+        <div id="map"></div>
+
+        <script src="scripts/mainView.js"></script>
+        <script async defer src="https://maps.googleapis.com/maps/api/js?key=AIzaSyDc-PXNJF7FQIv8rmGM3QaeUV10T5JiceQ&callback=app.mainView.initializeMap"></script>
+      </section>
+    <main>
+  </body>
+</html>

--- a/public/index.html
+++ b/public/index.html
@@ -2,7 +2,7 @@
 <html>
   <head>
     <title>Selfie Spots</title>
-
+    <link rel="stylesheet" href="vendor/styles/reset.css">
     <link rel="stylesheet" href="styles/modules.css">
   </head>
   <body>
@@ -13,6 +13,6 @@
         <script src="scripts/mainView.js"></script>
         <script async defer src="https://maps.googleapis.com/maps/api/js?key=AIzaSyDc-PXNJF7FQIv8rmGM3QaeUV10T5JiceQ&callback=app.mainView.initializeMap"></script>
       </section>
-    <main>
+    </main>
   </body>
 </html>

--- a/public/scripts/mainView.js
+++ b/public/scripts/mainView.js
@@ -1,0 +1,25 @@
+'use strict'
+
+var app = app || {};
+
+(function(module) {
+
+  var mainView = {}
+
+  mainView.initializeMap = function() {
+    var coordinates = {lat: 47.6182, lng: -122.3519};
+
+    var map = new google.maps.Map(document.getElementById('map'), {
+      zoom: 16,
+      center: coordinates
+    });
+
+    var marker = new google.maps.Marker({
+      position: coordinates,
+      map: map
+    });
+  }
+
+  module.mainView = mainView;
+
+})(app);

--- a/public/styles/modules.css
+++ b/public/styles/modules.css
@@ -1,0 +1,4 @@
+#map {
+  height: 400px;
+  width: 100%;
+}

--- a/public/styles/modules.css
+++ b/public/styles/modules.css
@@ -1,4 +1,4 @@
 #map {
-  height: 400px;
   width: 100%;
+  height: 100vh;
 }

--- a/server.js
+++ b/server.js
@@ -1,0 +1,17 @@
+'use strict';
+
+const express = require('express');
+const PORT = process.env.PORT || 3000;
+const app = express();
+
+app.use(express.static('./public'));
+
+app.get('/', function (request, response) {
+  response.sendFile('index.html', {root: './public'});
+});
+
+app.get('/home', function (request, response) {
+  response.sendFile('index.html', {root: './public'});
+});
+
+app.listen(PORT, () => console.log(`Server started on port ${PORT}.`));

--- a/server.js
+++ b/server.js
@@ -1,6 +1,8 @@
 'use strict';
 
+require('dotenv').config();
 const express = require('express');
+const requestProxy = require('express-request-proxy');
 const PORT = process.env.PORT || 3000;
 const app = express();
 
@@ -13,5 +15,12 @@ app.get('/', function (request, response) {
 app.get('/home', function (request, response) {
   response.sendFile('index.html', {root: './public'});
 });
+
+app.get('/ig/*', requestProxy({
+    url: 'https://api.instagram.com/v1/*',
+    query: {
+      access_token: process.env.INSTAGRAM_TOKEN
+    }
+}));
 
 app.listen(PORT, () => console.log(`Server started on port ${PORT}.`));


### PR DESCRIPTION
Adds server route to relay Instagram API calls. This adds the node module dotenv, which lets you store your environment variables and load them at runtime. See [here](https://www.npmjs.com/package/dotenv) for how to set that up. FYI, there is already a gitignore entry for a ".env" file.